### PR TITLE
fixed some auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,7 @@ SMTP_PORT=587
 
 # Frontend Configuration
 FRONTEND_URL=https://yourdomain.com
+
+# Server Configuration
+HOSTNAME=localhost
+PORT=3000

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,4 +1,6 @@
 {
-  "{**/*,**/.*/*,.*}.{js,jsx,ts,tsx,mjs}": ["eslint --fix", "prettier --write"],
-  "{**/*,**/.*/*,.*}.{json,css,md,yml,yaml,html}": ["prettier --write"]
+  "*.{js,jsx,ts,tsx,mjs}": ["eslint --fix", "prettier --write"],
+  "**/*.{js,jsx,ts,tsx,mjs}": ["eslint --fix", "prettier --write"],
+  "*.{json,css,md,yml,yaml}": ["prettier --write"],
+  "**/*.{json,css,md,yml,yaml}": ["prettier --write"]
 }

--- a/README.md
+++ b/README.md
@@ -1,29 +1,155 @@
 # Accountia API Documentation
 
-This is the API documentation for Accountia API. The API is a RESTful API that allows you to interact with the Accountia server. The API is used to create, read, update, and delete user data from the server.
+This is comprehensive API documentation for Accountia API. The API is a RESTful API that allows you to interact with Accountia server for user authentication, profile management, and email verification.
 
 ## Base URL
 
-http://localhost:3000/api/auth
+```
+http://localhost:3000/api
+```
+
+## Environment Configuration
+
+Required environment variables:
+
+```bash
+# Database
+MONGO_URI=mongodb://localhost:27017/accountia
+
+# JWT Configuration
+JWT_SECRET=your-super-secret-jwt-key-change-this-in-production
+JWT_EXPIRES_IN=24h
+JWT_REFRESH_EXPIRES_IN=168h # 7 days
+
+# Email Configuration (Gmail SMTP)
+GMAIL_USERNAME=your-email@gmail.com
+GMAIL_APP_PASSWORD=your-app-password
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+
+# Frontend Configuration
+FRONTEND_URL=https://yourdomain.com
+
+# Server Configuration
+HOSTNAME=localhost
+PORT=3000
+```
 
 ## API Documentation UI
 
-- The interactive Swagger UI is exposed at the `/docs` route under the API base path. For example, visit `http://localhost:3000/api/auth/docs` to view the API documentation and try endpoints.
+- The interactive Swagger UI is exposed at `/docs` route under the API base path
+- Visit `http://localhost:3000/api/docs` to view API documentation and test endpoints
 
-## Authentication
+## Global Configuration
 
-Protected routes require a valid JWT token in the Authorization header as a Bearer token.
+### Global Prefix
 
-### Example Authorization Header
+- All routes are prefixed with `/api`
 
-`Authorization: Bearer <your_jwt_token>`
+### Global Validation Pipe
+
+```typescript
+{
+  whitelist: true,           // Only allow defined properties
+  forbidNonWhitelisted: true, // Reject unknown properties
+  forbidUnknownValues: true,  // Strict validation
+  transform: true            // Auto-transform types
+}
+```
+
+### Global Exception Filter
+
+- `ConflictExceptionFilter` handles structured conflict responses
+- Preserves `type` field in conflict exceptions for frontend handling
+
+### CORS Configuration
+
+- Origin: `process.env.FRONTEND_URL`
+- Credentials: enabled
+
+### Swagger Configuration
+
+- Available in non-production environments
+- Bearer token authentication
+- Title: "Accountia API"
+- Version: "1.0"
+
+## Authentication & Authorization
+
+### JWT Strategy
+
+- **Access Token**: 24 hours expiration
+- **Refresh Token**: 7 days expiration
+- Token format: Bearer token in Authorization header
+
+### Guards
+
+- `JwtAuthGuard`: Protects authenticated routes
+- `RefreshJwtGuard`: Protects refresh token routes
+
+### User Payload Structure
+
+```typescript
+interface UserPayload {
+  id: string;
+  email: string;
+  username: string;
+  firstName: string;
+  lastName: string;
+  phoneNumber?: string;
+}
+```
 
 ## Endpoints
 
-**POST** `/register` - Register a new user
-Registers a new user in the system. Returns authentication tokens and user information or a map of validation errors.
+### Authentication Module
 
-**Request Body:**
+#### POST `/auth/register` - Register a new user
+
+**Basic Information**
+
+- **HTTP Method**: POST
+- **Route**: `/api/auth/register`
+- **Module**: Auth
+- **Controller**: AuthController
+- **Method**: `register`
+
+**Authentication & Authorization**
+
+- **Authentication Required**: No
+- **Guard**: None (public endpoint)
+- **Roles/Permissions**: None
+
+**Request Details**
+
+**Request Body (RegisterDto)**
+
+```typescript
+interface RegisterDto {
+  username: string; // Required, 5-20 chars
+  email: string; // Required, valid email
+  password: string; // Required, min 6 chars
+  firstName: string; // Required, 2-50 chars
+  lastName: string; // Required, 2-50 chars
+  birthdate: string; // Required, ISO date string
+  phoneNumber?: string; // Optional, string
+  acceptTerms: boolean; // Required, must be true
+  profilePicture?: string; // Optional, base64, max 7MB
+}
+```
+
+**Validation Rules**
+
+- `username`: `@IsNotEmpty()`, `@IsString()`, `@MinLength(5)`, `@MaxLength(20)`
+- `email`: `@IsNotEmpty()`, `@IsEmail()`
+- `password`: `@IsNotEmpty()`, `@IsString()`, `@MinLength(6)`
+- `firstName`: `@IsNotEmpty()`, `@IsString()`, `@MinLength(2)`, `@MaxLength(50)`
+- `lastName`: `@IsNotEmpty()`, `@IsString()`, `@MinLength(2)`, `@MaxLength(50)`
+- `birthdate`: `@IsNotEmpty()`, `@IsDateString()`
+- `acceptTerms`: `@IsNotEmpty()`, `@IsBoolean()`
+- `profilePicture`: `@IsOptional()`, `@IsString()`, `@MaxLength(9333334)`
+
+**Example Request Body**
 
 ```json
 {
@@ -35,85 +161,152 @@ Registers a new user in the system. Returns authentication tokens and user infor
   "birthdate": "2000-01-01",
   "phoneNumber": "+1234567890",
   "acceptTerms": true,
-  "profilePicture": "<base64 string>"
+  "profilePicture": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA..."
 }
 ```
 
-**Success Response:**
+**Response Documentation**
+
+**Success Response (201 Created)**
+
+- **Type**: `RegistrationResponseDto`
+- **Description**: User successfully registered, confirmation email sent
 
 ```json
 {
-  "accessToken": "<access_token>",
-  "refreshToken": "<refresh_token>",
-  "user": {
-    "id": "615f2e0a6c6d5c0e1a1e4a01",
-    "username": "john_doe",
-    "email": "john.doe@example.com",
-    "firstName": "John",
-    "lastName": "Doe",
-    "phoneNumber": "+1234567890"
-  }
+  "message": "Registration successful! Please check your email to confirm your account.",
+  "email": "john.doe@example.com"
 }
 ```
 
-**Validation Error Response:**
+**Error Responses**
+
+**Validation Error (400 Bad Request)**
+
+- **When**: Request body fails validation
 
 ```json
 {
+  "message": "Validation failed",
   "errors": {
     "username": "username must be at least 5 characters",
     "email": "invalid email format",
-    "password": "password must contain at least one uppercase, lowercase, number, or special character"
+    "password": "password must contain at least one uppercase, lowercase, number, or special character",
+    "acceptTerms": "You must accept the terms and conditions"
   }
 }
 ```
 
-**Conflict Response:**
+**Conflict Error (409 Conflict)**
+
+- **When**: User already exists
+
+_Unconfirmed User Exists:_
 
 ```json
 {
+  "type": "EMAIL_NOT_CONFIRMED",
+  "message": "Account exists but email is not confirmed. Please check your email or request a new confirmation.",
+  "email": "john.doe@example.com",
+  "userId": "507f1f77bcf86cd799439011"
+}
+```
+
+_Confirmed User Exists:_
+
+```json
+{
+  "type": "ACCOUNT_EXISTS",
   "message": "Username or email is already registered"
 }
 ```
 
-**Example Usage:**
+**Database & Business Logic Insights**
+
+- **Tables Involved**: `users` collection
+- **Relations**: None (single collection operation)
+- **Transactions**: Single document save
+- **Side Effects**:
+  - Password hashed with bcrypt (salt rounds: 10)
+  - Email confirmation token generated (32 hex chars)
+  - Confirmation email sent via EmailService
+- **Events Triggered**: None
+- **Queue Jobs**: None
+- **Caching**: None
+
+**Frontend Integration Notes**
 
 ```typescript
-const newUser: User = {
-  username: 'john_doe',
-  email: 'john.doe@example.com',
-  password: 'SecurePass123!',
-  firstName: 'John',
-  lastName: 'Doe',
-  acceptTerms: true,
-};
+// Common mistakes to avoid:
+// 1. Not checking for EMAIL_NOT_CONFIRMED type
+// 2. Not handling structured conflict responses
+// 3. Not showing resend confirmation button for unconfirmed users
 
-async function register(user: User) {
-  const response = await fetch(`${BASE_URL}/register`, {
+async function register(userData: RegisterDto) {
+  const response = await fetch(`${BASE_URL}/auth/register`, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(user),
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(userData),
   });
 
-  if (!response.ok) {
-    throw new Error('Registration failed');
-  }
-
   const data = await response.json();
-  return data;
-}
 
-register(newUser)
-  .then((data) => console.log(data))
-  .catch((error) => console.error(error));
+  if (response.ok) {
+    // Show success message, prompt email check
+    return { success: true, data };
+  } else if (response.status === 409) {
+    if (data.type === 'EMAIL_NOT_CONFIRMED') {
+      // Show "Resend Confirmation Email" button
+      return {
+        success: false,
+        type: 'EMAIL_NOT_CONFIRMED',
+        email: data.email,
+        userId: data.userId,
+      };
+    } else if (data.type === 'ACCOUNT_EXISTS') {
+      // Show "Account exists" error
+      return { success: false, type: 'ACCOUNT_EXISTS', message: data.message };
+    }
+  } else {
+    // Show validation errors
+    return { success: false, type: 'VALIDATION_ERROR', errors: data.errors };
+  }
+}
 ```
 
-**POST** `/login` - Login a user
-Logs in a user and returns user info and tokens. Returns validation errors or authentication errors as appropriate.
+#### POST `/auth/login` - Login a user
 
-**Request Body:**
+**Basic Information**
+
+- **HTTP Method**: POST
+- **Route**: `/api/auth/login`
+- **Module**: Auth
+- **Controller**: AuthController
+- **Method**: `login`
+
+**Authentication & Authorization**
+
+- **Authentication Required**: No
+- **Guard**: None (public endpoint)
+- **Roles/Permissions**: None
+
+**Request Details**
+
+**Request Body (LoginDto)**
+
+```typescript
+interface LoginDto {
+  email: string; // Required, valid email
+  password: string; // Required, string
+}
+```
+
+**Validation Rules**
+
+- `email`: `@IsNotEmpty()`, `@IsEmail()`
+- `password`: `@IsNotEmpty()`, `@IsString()`
+
+**Example Request Body**
 
 ```json
 {
@@ -122,12 +315,19 @@ Logs in a user and returns user info and tokens. Returns validation errors or au
 }
 ```
 
-**Success Response:**
+**Response Documentation**
+
+**Success Response (200 OK)**
+
+- **Type**: `AuthResponseDto`
+- **Description**: Login successful, tokens returned
 
 ```json
 {
-  "accessToken": "<access_token>",
-  "refreshToken": "<refresh_token>",
+  "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "accessTokenExpiresIn": "24h",
+  "refreshTokenExpiresIn": "7d",
   "user": {
     "id": "615f2e0a6c6d5c0e1a1e4a01",
     "username": "john_doe",
@@ -139,10 +339,15 @@ Logs in a user and returns user info and tokens. Returns validation errors or au
 }
 ```
 
-**Validation Error Response:**
+**Error Responses**
+
+**Validation Error (400 Bad Request)**
+
+- **When**: Request body fails validation
 
 ```json
 {
+  "message": "Validation failed",
   "errors": {
     "email": "email is required",
     "password": "password must contain at least one uppercase, lowercase, number, or special character"
@@ -150,80 +355,447 @@ Logs in a user and returns user info and tokens. Returns validation errors or au
 }
 ```
 
-**Authentication Error Response:**
+**Unauthorized Error (401 Unauthorized)**
+
+- **When**: Invalid credentials
 
 ```json
 {
-  "message": "Invalid email or password"
+  "statusCode": 401,
+  "message": "Invalid email or password",
+  "timestamp": "2024-02-17T16:30:00.000Z"
 }
 ```
+
+**Forbidden Error (403 Forbidden)**
+
+- **When**: Account locked
 
 ```json
 {
-  "message": "Account is temporarily locked due to too many failed attempts"
+  "statusCode": 403,
+  "message": "Account is temporarily locked due to too many failed attempts",
+  "timestamp": "2024-02-17T16:30:00.000Z"
 }
 ```
+
+- **When**: Account deactivated
 
 ```json
 {
-  "message": "Account is deactivated"
+  "statusCode": 403,
+  "message": "Account is deactivated",
+  "timestamp": "2024-02-17T16:30:00.000Z"
 }
 ```
+
+- **When**: Email not confirmed
 
 ```json
 {
-  "message": "Email not confirmed. Please confirm your email before logging in."
+  "statusCode": 403,
+  "message": "Email not confirmed. Please confirm your email before logging in.",
+  "timestamp": "2024-02-17T16:30:00.000Z"
 }
 ```
+
+**Too Many Requests (429 Too Many Requests)**
+
+- **When**: Rate limit exceeded
 
 ```json
 {
-  "message": "Too many failed login attempts. Please try again later."
+  "statusCode": 429,
+  "message": "Too many failed login attempts. Please try again later.",
+  "timestamp": "2024-02-17T16:30:00.000Z"
 }
 ```
 
-**Example Usage:**
+**Database & Business Logic Insights**
+
+- **Tables Involved**: `users` collection
+- **Relations**: None (single document lookup)
+- **Transactions**: None
+- **Side Effects**:
+  - Failed login attempts tracked (max 5, 15-minute lock)
+  - Rate limiting by IP and email identifier
+  - Refresh token stored in user document (max 10 tokens)
+  - Failed attempts cleared on successful login
+- **Events Triggered**: None
+- **Queue Jobs**: None
+- **Caching**: None
+
+**Rate Limiting Details**
+
+- **Max Attempts**: 5 failed attempts
+- **Window**: 10 minutes
+- **Block Duration**: 15 minutes
+- **Key Format**: `{ip}:{email}`
+
+**Frontend Integration Notes**
 
 ```typescript
+// Common mistakes to avoid:
+// 1. Not storing tokens securely
+// 2. Not handling different error types appropriately
+// 3. Not implementing token refresh logic
+// 4. Not clearing failed attempts on successful login
+
 async function login(email: string, password: string) {
-  const response = await fetch(`${BASE_URL}/login`, {
+  const response = await fetch(`${BASE_URL}/auth/login`, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ email, password }),
   });
 
-  if (!response.ok) {
-    throw new Error('Login failed');
-  }
-
   const data = await response.json();
-  return data;
-}
 
-login('john.doe@example.com', 'SecurePass123!')
-  .then((data) => console.log(data))
-  .catch((error) => console.error(error));
+  if (response.ok) {
+    // Store tokens securely
+    localStorage.setItem('accessToken', data.accessToken);
+    localStorage.setItem('refreshToken', data.refreshToken);
+
+    // Store user data
+    localStorage.setItem('user', JSON.stringify(data.user));
+
+    return { success: true, user: data.user };
+  } else if (response.status === 403) {
+    if (data.message.includes('not confirmed')) {
+      return {
+        success: false,
+        type: 'EMAIL_NOT_CONFIRMED',
+        message: data.message,
+      };
+    } else if (data.message.includes('locked')) {
+      return { success: false, type: 'ACCOUNT_LOCKED', message: data.message };
+    } else if (data.message.includes('deactivated')) {
+      return {
+        success: false,
+        type: 'ACCOUNT_DEACTIVATED',
+        message: data.message,
+      };
+    }
+  } else if (response.status === 429) {
+    return { success: false, type: 'RATE_LIMITED', message: data.message };
+  } else {
+    return {
+      success: false,
+      type: 'INVALID_CREDENTIALS',
+      message: data.message,
+    };
+  }
+}
 ```
 
-**PUT/PATCH** `/update` - Update user details
-Updates a user's details. Returns updated user info or validation errors.
+#### POST `/auth/logout` - Logout a user
 
-**Request Body:**
+**Basic Information**
+
+- **HTTP Method**: POST
+- **Route**: `/api/auth/logout`
+- **Module**: Auth
+- **Controller**: AuthController
+- **Method**: `logout`
+
+**Authentication & Authorization**
+
+- **Authentication Required**: Yes
+- **Guard**: `JwtAuthGuard`
+- **Roles/Permissions**: None
+
+**Request Details**
+
+**Headers Required**
+
+```
+Authorization: Bearer <access_token>
+Content-Type: application/json
+```
+
+**Request Body (RefreshTokenDto)**
+
+```typescript
+interface RefreshTokenDto {
+  refreshToken: string; // Required, valid refresh token
+}
+```
+
+**Validation Rules**
+
+- `refreshToken`: `@IsNotEmpty()`, `@IsString()`
+
+**Example Request Body**
 
 ```json
 {
-  "username": "john_doe_full",
-  "email": "john.doe.full@example.com",
-  "password": "new_password",
-  "firstName": "John",
-  "lastName": "Doe",
-  "birthdate": "2000-01-01",
-  "phoneNumber": "+1234567890",
-  "profilePicture": "<base64 string>"
+  "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
 }
 ```
+
+**Response Documentation**
+
+**Success Response (200 OK)**
+
+- **Type**: `void`
+- **Description**: Logout successful, refresh token invalidated
+- **Content**: No content returned
+
+**Error Responses**
+
+**Unauthorized Error (401 Unauthorized)**
+
+- **When**: Invalid or expired access token
+
+```json
+{
+  "statusCode": 401,
+  "message": "Unauthorized",
+  "timestamp": "2024-02-17T16:30:00.000Z"
+}
+```
+
+**Database & Business Logic Insights**
+
+- **Tables Involved**: `users` collection
+- **Relations**: None (single document update)
+- **Transactions**: None
+- **Side Effects**:
+  - Specific refresh token removed from user's refreshTokens array
+  - Other refresh tokens remain valid
+- **Events Triggered**: None
+- **Queue Jobs**: None
+- **Caching**: None
+
+**Frontend Integration Notes**
+
+```typescript
+// Common mistakes to avoid:
+// 1. Not clearing all stored tokens
+// 2. Not calling logout on token refresh failure
+// 3. Not handling network errors during logout
+
+async function logout(accessToken: string, refreshToken: string) {
+  try {
+    const response = await fetch(`${BASE_URL}/auth/logout`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({ refreshToken }),
+    });
+
+    // Clear local storage regardless of response
+    localStorage.removeItem('accessToken');
+    localStorage.removeItem('refreshToken');
+    localStorage.removeItem('user');
+
+    if (response.ok) {
+      return { success: true };
+    } else {
+      // Still clear tokens but indicate server error
+      return { success: false, error: 'Server logout failed' };
+    }
+  } catch (error) {
+    // Network error - still clear local tokens
+    localStorage.removeItem('accessToken');
+    localStorage.removeItem('refreshToken');
+    localStorage.removeItem('user');
+    return { success: false, error: 'Network error' };
+  }
+}
+```
+
+#### POST `/auth/refresh` - Refresh authentication tokens
+
+**Basic Information**
+
+- **HTTP Method**: POST
+- **Route**: `/api/auth/refresh`
+- **Module**: Auth
+- **Controller**: AuthController
+- **Method**: `refreshTokenHandler`
+
+**Authentication & Authorization**
+
+- **Authentication Required**: Yes
+- **Guard**: `RefreshJwtGuard`
+- **Roles/Permissions**: None
+
+**Request Details**
+
+**Headers Required**
+
+```
+Authorization: Bearer <refresh_token>
+```
+
+**Response Documentation**
+
+**Success Response (200 OK)**
+
+- **Type**: `AuthResponseDto`
+- **Description**: Tokens refreshed successfully
+
+```json
+{
+  "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "accessTokenExpiresIn": "24h",
+  "refreshTokenExpiresIn": "7d",
+  "user": {
+    "id": "615f2e0a6c6d5c0e1a1e4a01",
+    "username": "john_doe",
+    "email": "john.doe@example.com",
+    "firstName": "John",
+    "lastName": "Doe",
+    "phoneNumber": "+1234567890"
+  }
+}
+```
+
+**Error Responses**
+
+**Unauthorized Error (401 Unauthorized)**
+
+- **When**: Invalid refresh token
+
+```json
+{
+  "statusCode": 401,
+  "message": "Invalid refresh token",
+  "timestamp": "2024-02-17T16:30:00.000Z"
+}
+```
+
+- **When**: Refresh token expired
+
+```json
+{
+  "statusCode": 401,
+  "message": "Refresh token has expired",
+  "timestamp": "2024-02-17T16:30:00.000Z"
+}
+```
+
+**Database & Business Logic Insights**
+
+- **Tables Involved**: `users` collection
+- **Relations**: None (single document lookup and update)
+- **Transactions**: None
+- **Side Effects**:
+  - Old refresh token replaced with new one
+  - Expired tokens automatically cleaned up
+  - Max 10 refresh tokens per user maintained
+- **Events Triggered**: None
+- **Queue Jobs**: None
+- **Caching**: None
+
+**Token Management Details**
+
+- **Access Token Expiry**: 24 hours
+- **Refresh Token Expiry**: 7 days
+- **Max Refresh Tokens**: 10 per user
+- **Cleanup**: Expired tokens removed automatically
+
+**Frontend Integration Notes**
+
+```typescript
+// Common mistakes to avoid:
+// 1. Not storing new tokens after refresh
+// 2. Not handling refresh token expiration
+// 3. Not implementing automatic retry logic
+// 4. Not redirecting to login on refresh failure
+
+async function refreshTokens(refreshToken: string) {
+  try {
+    const response = await fetch(`${BASE_URL}/auth/refresh`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${refreshToken}`,
+      },
+    });
+
+    if (response.ok) {
+      const data = await response.json();
+
+      // Update stored tokens
+      localStorage.setItem('accessToken', data.accessToken);
+      localStorage.setItem('refreshToken', data.refreshToken);
+
+      return { success: true, tokens: data };
+    } else {
+      const error = await response.json();
+
+      // Clear tokens and redirect to login
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
+      localStorage.removeItem('user');
+
+      return {
+        success: false,
+        requiresLogin: true,
+        error: error.message,
+      };
+    }
+  } catch (error) {
+    // Network error - try once more then redirect
+    return { success: false, requiresLogin: true, error: 'Network error' };
+  }
+}
+
+// Automatic token refresh wrapper
+async function makeAuthenticatedRequest(
+  url: string,
+  options: RequestInit = {}
+) {
+  let accessToken = localStorage.getItem('accessToken');
+  let refreshToken = localStorage.getItem('refreshToken');
+
+  if (!accessToken || !refreshToken) {
+    throw new Error('No tokens available');
+  }
+
+  // Try original request
+  let response = await fetch(url, {
+    ...options,
+    headers: {
+      ...options.headers,
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  // If unauthorized, try refresh
+  if (response.status === 401) {
+    const refreshResult = await refreshTokens(refreshToken);
+
+    if (refreshResult.success) {
+      // Retry with new token
+      accessToken = localStorage.getItem('accessToken')!;
+      response = await fetch(url, {
+        ...options,
+        headers: {
+          ...options.headers,
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+    }
+  }
+
+  return response;
+}
+```
+
+"email": "john.doe.full@example.com",
+"password": "new_password",
+"firstName": "John",
+"lastName": "Doe",
+"birthdate": "2000-01-01",
+"phoneNumber": "+1234567890",
+"profilePicture": "<base64 string>"
+}
+
+````
 
 **Success Response:**
 
@@ -241,7 +813,7 @@ Updates a user's details. Returns updated user info or validation errors.
     "emailConfirmed": false
   }
 }
-```
+````
 
 **Validation Error Response:**
 
@@ -427,31 +999,28 @@ Refreshes an access token and returns new tokens. Requires a valid refresh token
 }
 ```
 
-**Email Verification**
+#### GET `/auth/confirm-email/:token` - Confirm email address
 
-**GET** `/confirm-email/:token` - Confirm email address
+Confirms a user's email address using a token. Returns HTML page instead of JSON.
 
 **URL Parameters:**
 
 - `token` (string): Email confirmation token
 
-**Success Response:**
+**Success Response (200 OK):**
+Returns HTML confirmation page with success message and styling.
 
-```json
-{
-  "success": true,
-  "message": "Email confirmed successfully"
-}
+**Error Response (200 OK):**
+Returns HTML confirmation page with error message and styling.
+
+**Example:**
+
+```
+GET http://localhost:3000/auth/confirm-email/abc123def456
 ```
 
-**Error Response:**
-
-```json
-{
-  "success": false,
-  "message": "Invalid confirmation token"
-}
-```
+**Frontend Integration:**
+This endpoint is designed to be opened directly in a browser from the email confirmation link. It returns a user-friendly HTML page instead of JSON for better user experience.
 
 **GET** `/resend-confirmation-email` - Resend confirmation email
 
@@ -564,6 +1133,94 @@ All validation errors are returned as an `errors` object mapping field names to 
 - Passwords must meet complexity requirements.
 - Email and username uniqueness is enforced on registration and update.
 - All error responses are designed for easy frontend parsing.
+
+## TypeScript Interfaces for Frontend Integration
+
+### AuthResponseDto
+
+```typescript
+interface AuthResponseDto {
+  accessToken: string;
+  refreshToken: string;
+  accessTokenExpiresIn: string; // "24h"
+  refreshTokenExpiresIn: string; // "7d"
+  user: {
+    id: string;
+    username: string;
+    email: string;
+    firstName?: string;
+    lastName?: string;
+    phoneNumber?: string;
+  };
+}
+```
+
+### RegistrationResponseDto
+
+```typescript
+interface RegistrationResponseDto {
+  message: string;
+  email: string;
+}
+```
+
+### LoginDto
+
+```typescript
+interface LoginDto {
+  email: string;
+  password: string;
+}
+```
+
+### RefreshTokenDto
+
+```typescript
+interface RefreshTokenDto {
+  refreshToken: string;
+}
+```
+
+### Token Management Usage Examples
+
+```typescript
+// Store tokens with expiry information
+const loginResponse = await login(email, password);
+localStorage.setItem('accessToken', loginResponse.accessToken);
+localStorage.setItem('refreshToken', loginResponse.refreshToken);
+localStorage.setItem(
+  'accessTokenExpiresIn',
+  loginResponse.accessTokenExpiresIn
+);
+localStorage.setItem(
+  'refreshTokenExpiresIn',
+  loginResponse.refreshTokenExpiresIn
+);
+
+// Calculate when tokens expire
+const getExpiryTime = (expiresIn: string): Date => {
+  const now = new Date();
+  if (expiresIn === '24h') {
+    return new Date(now.getTime() + 24 * 60 * 60 * 1000);
+  } else if (expiresIn === '7d') {
+    return new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+  }
+  return now;
+};
+
+// Check if token needs refresh
+const needsRefresh = (expiresIn: string): boolean => {
+  const expiry = getExpiryTime(expiresIn);
+  const fiveMinutesFromNow = new Date(Date.now() + 5 * 60 * 1000);
+  return expiry <= fiveMinutesFromNow;
+};
+
+// Automatic refresh logic
+if (needsRefresh('24h')) {
+  const refreshResponse = await refreshTokens(refreshToken);
+  // Update stored tokens and expiry times
+}
+```
 
 ### License
 

--- a/src/auth/dto/registration-response.dto.ts
+++ b/src/auth/dto/registration-response.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class RegistrationResponseDto {
+  @ApiProperty({
+    example:
+      'Registration successful! Please check your email to confirm your account.',
+    description: 'Success message for registration',
+  })
+  message: string;
+
+  @ApiProperty({
+    example: 'user@example.com',
+    description: 'User email address',
+  })
+  email: string;
+}

--- a/src/auth/dto/resend-confirmation.dto.ts
+++ b/src/auth/dto/resend-confirmation.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsNotEmpty } from 'class-validator';
+
+export class ResendConfirmationDto {
+  @ApiProperty({
+    example: 'user@example.com',
+    description: 'Email address to resend confirmation to',
+  })
+  @IsNotEmpty()
+  @IsEmail()
+  email: string;
+}

--- a/src/auth/email.service.ts
+++ b/src/auth/email.service.ts
@@ -10,6 +10,7 @@ export class EmailService {
   private readonly smtpHost: string;
   private readonly smtpPort: string;
   private readonly frontendUrl: string;
+  private readonly apiUrl: string;
 
   constructor() {
     if (
@@ -44,10 +45,15 @@ export class EmailService {
     this.smtpHost = process.env.SMTP_HOST ?? 'smtp.gmail.com';
     this.smtpPort = process.env.SMTP_PORT ?? '587';
     this.frontendUrl = process.env.FRONTEND_URL;
+
+    const port = process.env.PORT ?? '3000';
+    const host = process.env.HOSTNAME ?? 'localhost';
+    const protocol = host === 'localhost' ? 'http' : 'https';
+    this.apiUrl = `${protocol}://${host}:${port}`;
   }
 
   async sendConfirmationEmail(email: string, token: string): Promise<void> {
-    const confirmationLink = `${this.frontendUrl}/api/auth/confirm-email/${token}`;
+    const confirmationLink = `${this.apiUrl}/auth/confirm-email/${token}`;
 
     try {
       const templatePath = path.join(

--- a/src/auth/templates/email_confirmed.html
+++ b/src/auth/templates/email_confirmed.html
@@ -1,0 +1,146 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Email Confirmed - Accountia</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        line-height: 1.6;
+        color: #333;
+        max-width: 600px;
+        margin: 0 auto;
+        padding: 20px;
+        background-color: #f4f4f4;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .container {
+        background-color: #ffffff;
+        padding: 40px;
+        border-radius: 10px;
+        box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
+        text-align: center;
+      }
+      .header {
+        margin-bottom: 30px;
+      }
+      .logo {
+        font-size: 32px;
+        font-weight: bold;
+        color: #007bff;
+        margin-bottom: 20px;
+      }
+      .success-icon {
+        width: 80px;
+        height: 80px;
+        background-color: #28a745;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin: 0 auto 30px;
+      }
+      .success-icon::after {
+        content: '✓';
+        color: white;
+        font-size: 40px;
+        font-weight: bold;
+      }
+      .title {
+        font-size: 24px;
+        color: #28a745;
+        margin-bottom: 15px;
+      }
+      .message {
+        font-size: 16px;
+        color: #666;
+        margin-bottom: 30px;
+        line-height: 1.8;
+      }
+      .button {
+        display: inline-block;
+        background-color: #007bff;
+        color: #ffffff;
+        padding: 12px 30px;
+        text-decoration: none;
+        border-radius: 5px;
+        font-weight: bold;
+        margin: 20px 0;
+        transition: background-color 0.3s ease;
+      }
+      .button:hover {
+        background-color: #0056b3;
+      }
+      .footer {
+        margin-top: 40px;
+        padding-top: 20px;
+        border-top: 1px solid #eee;
+        font-size: 14px;
+        color: #666;
+      }
+      .error-message {
+        background-color: #f8d7da;
+        color: #721c24;
+        padding: 15px;
+        border-radius: 5px;
+        margin-bottom: 20px;
+        border: 1px solid #f5c6cb;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="header">
+        <div class="logo">Accountia</div>
+        {{if .Success}}
+        <div class="success-icon"></div>
+        <h1 class="title">Email Confirmed Successfully!</h1>
+        {{else}}
+        <h1 class="title" style="color: #dc3545">Email Confirmation Failed</h1>
+        {{end}}
+      </div>
+
+      <div class="content">
+        {{if .Success}}
+        <p class="message">
+          Thank you for confirming your email address! Your Accountia account is
+          now active and ready to use. You can now log in and start using all
+          our features.
+        </p>
+
+        <p class="message">
+          You can now close this window and return to the application to log in.
+        </p>
+        {{else}}
+        <div class="error-message">{{.Message}}</div>
+
+        <p class="message">
+          We're sorry, but we couldn't confirm your email address. This might be
+          because:
+        </p>
+
+        <ul style="text-align: left; max-width: 400px; margin: 0 auto">
+          <li>The confirmation link has expired</li>
+          <li>The link has already been used</li>
+          <li>The link is invalid or corrupted</li>
+        </ul>
+
+        <p class="message">
+          Please try requesting a new confirmation email from your account
+          settings, or contact our support team if you continue to experience
+          issues.
+        </p>
+        {{end}}
+      </div>
+
+      <div class="footer">
+        <p>&copy; {{.Year}} Accountia. All rights reserved.</p>
+        <p>This is an automated confirmation page.</p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/common/filters/conflict-exception.filter.ts
+++ b/src/common/filters/conflict-exception.filter.ts
@@ -1,0 +1,35 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  HttpException,
+} from '@nestjs/common';
+import { Response } from 'express';
+
+@Catch(HttpException)
+export class ConflictExceptionFilter implements ExceptionFilter {
+  catch(exception: HttpException, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const status = exception.getStatus();
+
+    if (status === 409) {
+      const exceptionResponse = exception.getResponse();
+
+      if (
+        typeof exceptionResponse === 'object' &&
+        exceptionResponse !== null &&
+        'type' in exceptionResponse
+      ) {
+        response.status(status).json(exceptionResponse);
+        return;
+      }
+    }
+
+    response.status(status).json({
+      statusCode: status,
+      message: exception.message,
+      timestamp: new Date().toISOString(),
+    });
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,13 +2,13 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from '@/app.module';
 import { ValidationPipe } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { ConflictExceptionFilter } from '@/common/filters/conflict-exception.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
   app.setGlobalPrefix('api');
 
-  // Enable CORS for frontend
   app.enableCors({
     origin: process.env.FRONTEND_URL,
     credentials: true,
@@ -22,6 +22,8 @@ async function bootstrap() {
       transform: true,
     })
   );
+
+  app.useGlobalFilters(new ConflictExceptionFilter());
 
   if (process.env.NODE_ENV !== 'production') {
     const config = new DocumentBuilder()
@@ -49,7 +51,7 @@ async function bootstrap() {
 
   const docsUrl =
     process.env.NODE_ENV === 'production'
-      ? `Port ${port} - /api`
+      ? `Port ${port} - /api/docs`
       : `http://localhost:${String(port)}/api/docs`;
   console.log(`🚀 API running on ${docsUrl}`);
 }

--- a/src/users/schemas/user.schema.ts
+++ b/src/users/schemas/user.schema.ts
@@ -78,12 +78,12 @@ export class User {
 
 export const UserSchema = SchemaFactory.createForClass(User);
 
-UserSchema.pre(
-  'save',
-  function (this: UserDocument, next: (err?: Error) => void) {
-    if (this.refreshTokens && this.refreshTokens.length > 10) {
-      this.refreshTokens = this.refreshTokens.slice(-10);
-    }
-    next();
+UserSchema.pre('save', function () {
+  if (
+    this.refreshTokens &&
+    Array.isArray(this.refreshTokens) &&
+    this.refreshTokens.length > 10
+  ) {
+    this.refreshTokens = this.refreshTokens.slice(-10);
   }
-);
+});


### PR DESCRIPTION
### TL;DR

Added server configuration to environment variables and enhanced API documentation with comprehensive endpoint details.

### What changed?

- Added `HOSTNAME` and `PORT` environment variables to `.env.example`
- Completely revamped the README.md with detailed API documentation including:
  - Environment configuration requirements
  - Authentication strategies and token management
  - Comprehensive endpoint documentation with request/response examples
  - Frontend integration notes and common mistakes to avoid
- Updated email confirmation to return HTML instead of JSON for better UX
- Added a custom `ConflictExceptionFilter` to preserve structured error responses
- Created a new `RegistrationResponseDto` for better registration flow
- Enhanced error handling for existing users with different response types
- Updated API URL construction to use environment variables

### Why make this change?

This change improves developer experience by providing more detailed API documentation with practical examples and integration notes. The server configuration variables make deployment more flexible, while the enhanced error handling provides better feedback for frontend applications. The HTML email confirmation page creates a more professional user experience compared to the previous JSON response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTML confirmation page and email verification flow for registrations.
  * Resend-confirmation request by email.

* **Documentation**
  * Major rewrite of API docs with detailed auth endpoints, request/response schemas, TypeScript examples, and frontend guidance.

* **Improvements**
  * Registration now returns a message+email (no access/refresh tokens on register) and requires email confirmation.
  * Clearer 409/conflict responses via a new conflict handler.
* **Chores**
  * Added HOSTNAME and PORT env examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->