### PR TITLE
added ban/unban

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -55,6 +55,7 @@ import { type UserPayload } from '@/auth/types/auth.types';
 import { TwoFASetupResponseDto } from '@/auth/dto/2fa-setup.dto';
 import { TwoFAVerifyDto } from '@/auth/dto/2fa-verify.dto';
 import { TwoFALoginDto } from '@/auth/dto/2fa-login.dto';
+import { BanUserDto, BanResponseDto } from '@/auth/dto/ban-user.dto';
 
 @ApiTags('Authentication')
 @ApiExtraModels(AuthResponseDto)
@@ -503,5 +504,54 @@ export class AuthController {
       changeRoleDto.newRole,
       currentUser
     );
+  }
+
+  @Patch('users/:id/ban')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.PLATFORM_OWNER, Role.PLATFORM_ADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Ban a user (Platform Owner/Admin only)' })
+  @ApiResponse({
+    status: 200,
+    description: 'User banned successfully',
+    type: BanResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Bad request' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden - Insufficient permissions',
+  })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  async banUser(
+    @CurrentUser() currentUser: UserPayload,
+    @Param('id') id: string,
+    @Body() banDto: BanUserDto
+  ): Promise<BanResponseDto> {
+    return this.authService.banUser(currentUser.id, id, banDto.reason);
+  }
+
+  @Patch('users/:id/unban')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.PLATFORM_OWNER, Role.PLATFORM_ADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Unban a user (Platform Owner/Admin only)' })
+  @ApiResponse({
+    status: 200,
+    description: 'User unbanned successfully',
+    type: BanResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Bad request' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden - Insufficient permissions',
+  })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  async unbanUser(
+    @CurrentUser() currentUser: UserPayload,
+    @Param('id') id: string
+  ): Promise<BanResponseDto> {
+    return this.authService.unbanUser(currentUser.id, id);
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -35,6 +35,7 @@ import { EmailService } from '@/auth/email.service';
 import { RateLimitingService } from '@/auth/rate-limiting.service';
 import { Role } from '@/auth/enums/role.enum';
 import { RoleResponseDto } from '@/auth/dto/role-response.dto';
+import { BanResponseDto } from '@/auth/dto/ban-user.dto';
 import { type UserPayload } from '@/auth/types/auth.types';
 
 interface TokenPayload {
@@ -499,6 +500,11 @@ export class AuthService {
         'Email not confirmed. Please confirm your email before logging in.'
       );
     }
+    if (user.isBanned) {
+      throw new ForbiddenException(
+        'Your account has been banned. Please contact support.'
+      );
+    }
     const isPasswordValid = await compare(password, user.passwordHash);
     if (!isPasswordValid) {
       await this.handleFailedLogin(user);
@@ -757,6 +763,8 @@ export class AuthService {
       phoneNumber: u.phoneNumber,
       role: u.role,
       dateJoined: u.createdAt,
+      isBanned: u.isBanned ?? false,
+      bannedReason: u.bannedReason,
     }));
 
     return {
@@ -1194,6 +1202,90 @@ export class AuthService {
     }
 
     return `user-${randomBytes(4).toString('hex')}`;
+  }
+
+  async banUser(
+    adminId: string,
+    userId: string,
+    reason?: string
+  ): Promise<BanResponseDto> {
+    if (adminId === userId) {
+      throw new BadRequestException('You cannot ban yourself');
+    }
+
+    const [admin, user] = await Promise.all([
+      this.userModel.findById(adminId),
+      this.userModel.findById(userId),
+    ]);
+
+    if (!admin) throw new NotFoundException('Admin not found');
+    if (!user) throw new NotFoundException('User not found');
+
+    if (
+      admin.role === Role.PLATFORM_ADMIN &&
+      (user.role === Role.PLATFORM_OWNER || user.role === Role.PLATFORM_ADMIN)
+    ) {
+      throw new ForbiddenException(
+        'Platform Admin cannot ban Platform Owner or Platform Admin'
+      );
+    }
+
+    if (user.isBanned) {
+      throw new BadRequestException('User is already banned');
+    }
+
+    user.isBanned = true;
+    user.bannedAt = new Date();
+    user.bannedBy = adminId;
+    user.bannedReason = reason;
+    user.refreshTokens = [];
+    await user.save();
+
+    return {
+      message: 'User banned successfully',
+      userId: user._id.toString(),
+      isBanned: true,
+      reason,
+    };
+  }
+
+  async unbanUser(adminId: string, userId: string): Promise<BanResponseDto> {
+    if (adminId === userId) {
+      throw new BadRequestException('You cannot unban yourself');
+    }
+
+    const [admin, user] = await Promise.all([
+      this.userModel.findById(adminId),
+      this.userModel.findById(userId),
+    ]);
+
+    if (!admin) throw new NotFoundException('Admin not found');
+    if (!user) throw new NotFoundException('User not found');
+
+    if (
+      admin.role === Role.PLATFORM_ADMIN &&
+      (user.role === Role.PLATFORM_OWNER || user.role === Role.PLATFORM_ADMIN)
+    ) {
+      throw new ForbiddenException(
+        'Platform Admin cannot unban Platform Owner or Platform Admin'
+      );
+    }
+
+    if (!user.isBanned) {
+      throw new BadRequestException('User is not banned');
+    }
+
+    user.isBanned = false;
+    user.bannedAt = undefined;
+    user.bannedBy = undefined;
+    user.bannedReason = undefined;
+    await user.save();
+
+    return {
+      message: 'User unbanned successfully',
+      userId: user._id.toString(),
+      isBanned: false,
+    };
   }
 
   async changeUserRole(

--- a/src/auth/dto/ban-user.dto.ts
+++ b/src/auth/dto/ban-user.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class BanUserDto {
+  @ApiPropertyOptional({ example: 'Violation of terms of service' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  reason?: string;
+}
+
+export class BanResponseDto {
+  @ApiProperty({ example: 'User banned successfully' })
+  message: string;
+
+  @ApiProperty({ example: '507f1f77bcf86cd799439011' })
+  userId: string;
+
+  @ApiProperty({ example: true })
+  isBanned: boolean;
+
+  @ApiPropertyOptional({ example: 'Violation of terms of service' })
+  reason?: string;
+}

--- a/src/auth/dto/users-list.dto.ts
+++ b/src/auth/dto/users-list.dto.ts
@@ -31,6 +31,12 @@ export class UserSummaryDto {
 
   @ApiProperty({ example: '2023-01-01T00:00:00.000Z' })
   dateJoined!: Date;
+
+  @ApiProperty({ example: false })
+  isBanned!: boolean;
+
+  @ApiPropertyOptional({ example: 'Violation of terms of service' })
+  bannedReason?: string;
 }
 
 export class UsersListResponseDto {

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -26,6 +26,9 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     if (!user) {
       throw new UnauthorizedException('User not found');
     }
+    if (user.isBanned) {
+      throw new UnauthorizedException('Your account has been banned');
+    }
     return {
       id: user._id.toString(),
       email: user.email,

--- a/src/users/schemas/user.schema.ts
+++ b/src/users/schemas/user.schema.ts
@@ -79,6 +79,18 @@ export class User {
   @Prop()
   lockUntil?: Date;
 
+  @Prop({ default: false })
+  isBanned: boolean;
+
+  @Prop()
+  bannedAt?: Date;
+
+  @Prop()
+  bannedBy?: string;
+
+  @Prop()
+  bannedReason?: string;
+
   @Prop()
   createdAt: Date;
 


### PR DESCRIPTION
### TL;DR

Added user ban/unban functionality for Platform Owners and Admins with proper role-based access controls and authentication checks.

### What changed?

- Added `banUser` and `unbanUser` endpoints in the auth controller restricted to Platform Owner and Platform Admin roles
- Implemented ban status validation in login flow and JWT strategy to prevent banned users from accessing the system
- Extended User schema with ban-related fields: `isBanned`, `bannedAt`, `bannedBy`, and `bannedReason`
- Created `BanUserDto` and `BanResponseDto` for request/response handling
- Updated users list response to include ban status and reason
- Added role hierarchy validation preventing Platform Admins from banning other admins or owners
- Implemented automatic refresh token clearing when users are banned

### Why make this change?

This implements essential user moderation capabilities allowing platform administrators to manage problematic users by temporarily or permanently restricting their access while maintaining proper authorization controls and audit trails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Platform admins can now ban and unban users with optional reasons
  * Banned users are prevented from logging in to their accounts
  * User management listings display ban status and ban reason information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->