### PR TITLE
tensor rebuild only in prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "prepare": "husky",
-    "postinstall": "npm rebuild @tensorflow/tfjs-node --build-addon-from-source"
+    "postinstall": "if [ \"$NODE_ENV\" = \"production\" ]; then npm rebuild @tensorflow/tfjs-node --build-addon-from-source; fi"
   },
   "dependencies": {
     "@multiavatar/multiavatar": "^1.0.7",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized installation process by skipping native addon rebuilding in non-production environments, improving setup time for development installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->